### PR TITLE
Add a changelog to the project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to `pyprefab` are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com), and the project uses [Semantic Versioning](https://semver.org/).
+
+## [Unreleased]
+
+### Added
+
+- New templates for GitHub workflows: ci (linting, tests, and coverage), publishing to TestPyPI, and publishing to PyPI
+- Project changelog
+
+## [0.3.2] - [2025-01-13](https://github.com/bsweger/pyprefab/compare/v0.3.1...v0.3.2)
+
+### Changed
+
+- Rename CLI command to `pyprefab`
+
+## [0.3.1] - [2025-01-13](https://github.com/bsweger/pyprefab/compare/v0.3.0...v0.3.1)
+
+### Added
+
+- New templates for generating Python package boilerplate: .gitignore, README.md, app.py
+
+### Changed
+
+- Rename project to `pyprefab`
+
+### Removed
+
+- Removed sample `hello_world` module in favor of template-driven boilerplate
+
+## [0.3.0] - [2025-01-12](https://github.com/bsweger/pyprefab/compare/v0.2.1...v0.3.0)
+
+### Added
+
+- Added `pyproject.toml` template as the first piece of template-driven Python boilerplate
+
+### Removed
+
+- Removed artifacts from prior iteration of `pyprefab` that pre-dates the template-drive approach

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ pyprefab = "pyprefab.cli:app"
 
 [project.urls]
 Repository = "https://github.com/bsweger/pyprefab.git"
+Changelog = "https://github.com/bsweger/pyprefab/blob/main/CHANGELOG.md"
 
 [build-system]
 # Minimum requirements for the build system to execute.


### PR DESCRIPTION
Follow guidelines on keepachangelog.com to create a public-facing document of pyprefab changes.