### PR TITLE
Security updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,28 @@
+# instruct GitHub dependabot to scan github actions for updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # dependabot automatically checks .github/workflows/ and .github/actions/
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      gha-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+
+  - package-ecosystem: "uv"
+    # Location of `uv.lock` and/or `pyproject.toml`
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      py-updates:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor
+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: "1"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 #v5.4.0
         with:
             version: ">=0.0.1"
 
@@ -51,7 +51,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 #v5.4.0
         with:
             python-version: ${{ matrix.python-version }}
             version: ">=0.0.1"
@@ -84,7 +84,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 #v5.4.0
         with:
           version: '>=0.0.1'
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -35,7 +35,7 @@ jobs:
           persist-credentials: false
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355  # v5.2.2
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 #v5.4.0
 
       - name: Build Sphinx docs 🗿
         shell: bash

--- a/.github/workflows/publish-pypi-test.yaml
+++ b/.github/workflows/publish-pypi-test.yaml
@@ -9,6 +9,9 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution 📦

--- a/.github/workflows/publish-pypi-test.yaml
+++ b/.github/workflows/publish-pypi-test.yaml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-python@v5
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 #v5.4.0
         with:
           version: ">=0.0.1"
 
@@ -60,6 +60,6 @@ jobs:
         name: package-distribution
         path: dist/
     - name: Publish distribution to test PyPI 🚀
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc #v1.12.4
       with:
         repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -10,6 +10,9 @@ on:
       # only run workflow for tags in release format
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution 📦

--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/setup-python@v5
 
       - name: Install uv 🌟
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@22695119d769bdb6f7032ad67b9bca0ef8c4a174 #v5.4.0
         with:
           version: ">=0.0.1"
 
@@ -61,7 +61,7 @@ jobs:
         name: package-distribution
         path: dist/
     - name: Publish distribution to PyPI 🚀
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc #v1.12.4
 
   github-release:
     name: >-
@@ -82,7 +82,7 @@ jobs:
         name: package-distribution
         path: dist/
     - name: Sign the dists with Sigstore 📝
-      uses: sigstore/gh-action-sigstore-python@v3.0.0
+      uses: sigstore/gh-action-sigstore-python@f514d46b907ebcd5bedc05145c03b69c1edd8b46 #v3.0.0
       with:
         inputs: >-
           ./dist/*.tar.gz

--- a/src/pyprefab/cli.py
+++ b/src/pyprefab/cli.py
@@ -7,7 +7,7 @@ from typing import Optional
 
 import structlog
 import typer
-from jinja2 import Environment, FileSystemLoader
+from jinja2 import Environment, FileSystemLoader, select_autoescape
 from rich import print
 from rich.console import Console
 from rich.panel import Panel
@@ -49,12 +49,14 @@ def render_templates(context: dict, templates_dir: Path, target_dir: Path):
         trim_blocks=True,
         lstrip_blocks=True,
         keep_trailing_newline=True,
+        autoescape=select_autoescape(),
     )
     # For rendering path names
     path_env = Environment(
         trim_blocks=True,
         lstrip_blocks=True,
         keep_trailing_newline=True,
+        autoescape=select_autoescape(),
     )
 
     for template_file in templates_dir.rglob('*'):

--- a/src/pyprefab/templates/.github/workflows/ci.yaml.j2
+++ b/src/pyprefab/templates/.github/workflows/ci.yaml.j2
@@ -7,6 +7,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   FORCE_COLOR: "1"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"

--- a/src/pyprefab/templates/.github/workflows/publish-pypi-test.yaml.j2
+++ b/src/pyprefab/templates/.github/workflows/publish-pypi-test.yaml.j2
@@ -23,6 +23,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution 📦

--- a/src/pyprefab/templates/.github/workflows/publish-pypi.yaml.j2
+++ b/src/pyprefab/templates/.github/workflows/publish-pypi.yaml.j2
@@ -22,6 +22,9 @@ on:
       # only run workflow for tags in release format
       - "v[0-9]+.[0-9]+.[0-9]+"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build distribution 📦


### PR DESCRIPTION
Implement some GitHub-recommended practices for code and GitHub action security:

- Pin third-party actions by commit SHA instead of tag
- Add explicit permissions to GitHub workflows
- Configure dependabot