### PR TITLE
Add an "exception list" for existing directory content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `pyprefab` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com), and the
 project uses [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- Allow package creation in directories that already contain a `.git` folder
+  (to prevent inadvertent overwriting, pyprefab will not create a package in
+  a directory with existing content aside from `.git/`)
+
 ## 0.5.4
 
 ### Added

--- a/src/pyprefab/cli.py
+++ b/src/pyprefab/cli.py
@@ -137,7 +137,12 @@ def main(
         )
         raise typer.Exit(1)
 
-    if project_dir.exists() and any(project_dir.iterdir()):
+    # If there is already content in the project directory, exit (unless
+    # the directory is on the exception list below)
+    allow_existing = ['.git']
+    exceptions = [allow for allow in allow_existing if (project_dir / allow).is_dir()]
+
+    if project_dir.exists() and sum(1 for item in project_dir.iterdir()) - len(exceptions) > 0:
         err_console = Console(stderr=True)
         err_console.print(
             Panel.fit(

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -78,3 +78,34 @@ def test_error_existing_data(tmp_path):
         input='y\n',
     )
     assert result.exit_code != 0
+
+
+def test_existing_data_exception(tmp_path):
+    """If existing files in project directory are on the exception list, pyprefab should create the package."""
+
+    project_dir = tmp_path / 'test_existing_data'
+    (project_dir / '.git').mkdir(parents=True, exist_ok=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ['--name', 'pytest_project', '--author', 'Py Test', '--description', 'new project', '--dir', project_dir],
+        input='y\n',
+    )
+    assert result.exit_code == 0
+
+
+def test_existing_data_exception_and_no_exception(tmp_path):
+    """If there's a mix of allowed and not allowed existing files in project directory, pyprefab should fail."""
+
+    project_dir = tmp_path / 'test_existing_data'
+    (project_dir / '.git').mkdir(parents=True, exist_ok=True)
+    (project_dir / 'logs').mkdir(parents=True, exist_ok=True)
+
+    runner = CliRunner()
+    result = runner.invoke(
+        app,
+        ['--name', 'pytest_project', '--author', 'Py Test', '--description', 'new project', '--dir', project_dir],
+        input='y\n',
+    )
+    assert result.exit_code != 0


### PR DESCRIPTION
To prevent overwriting data, pyprefab will not create a package in a directory with existing content. This changeset makes an exception for target directories that have a ".git" folder and nothing else.

Making this exception allows users to initialize a repo or clone an empty repo before running pyprefab.