### PR TITLE
Move package name validation to a callback function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to `pyprefab` are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com), and the
 project uses [Semantic Versioning](https://semver.org/).
 
+## Unreleased
+
+### Changed
+
+- In interactive mode, Pyprefab now returns an immediate error message
+  for invalid package names instead of waiting until the rest of the prompts
+  are filled out.
+
 ## 0.5.5
 
 ### Added

--- a/src/pyprefab/cli.py
+++ b/src/pyprefab/cli.py
@@ -15,6 +15,7 @@ from rich.panel import Panel
 from rich.theme import Theme
 from typing_extensions import Annotated
 
+from pyprefab.exceptions import PyprefabBadParameter
 from pyprefab.logging import setup_logging
 
 setup_logging()
@@ -37,16 +38,16 @@ app = typer.Typer(
 )
 
 
-def validate_package_name(name: str) -> bool:
-    """Validate package name follows Python package naming conventions."""
-    if name.isidentifier():
-        return name
+def validate_package_name(value: str) -> str:
+    """Validate that package name follows Python package naming conventions."""
+    if not value.isidentifier():
+        if value[0].isdigit():
+            msg = 'Python package names cannot start with a number'
+        else:
+            msg = 'Python package names must contain letters, numbers, or underscores'
+        raise PyprefabBadParameter(msg)
     else:
-        raise typer.BadParameter(
-            f'{name} is not a valid Python package name.\n'
-            'Package names can contain letters, numbers, and underscores. They cannot start with a number.\n'
-            'See https://docs.python.org/3/reference/lexical_analysis.html#identifiers for more information.'
-        )
+        return value
 
 
 def render_templates(context: dict, templates_dir: Path, target_dir: Path):

--- a/src/pyprefab/cli.py
+++ b/src/pyprefab/cli.py
@@ -39,7 +39,14 @@ app = typer.Typer(
 
 def validate_package_name(name: str) -> bool:
     """Validate package name follows Python package naming conventions."""
-    return name.isidentifier() and name.islower()
+    if name.isidentifier():
+        return name
+    else:
+        raise typer.BadParameter(
+            f'{name} is not a valid Python package name.\n'
+            'Package names can contain letters, numbers, and underscores. They cannot start with a number.\n'
+            'See https://docs.python.org/3/reference/lexical_analysis.html#identifiers for more information.'
+        )
 
 
 def render_templates(context: dict, templates_dir: Path, target_dir: Path):
@@ -91,6 +98,7 @@ def main(
         typer.Option(
             help='Name of the package',
             prompt=typer.style('Package name 🐍', fg=typer.colors.MAGENTA, bold=True),
+            callback=validate_package_name,
             show_default=False,
         ),
     ],
@@ -127,17 +135,6 @@ def main(
     """
     🐍 Create Python package boilerplate 🐍
     """
-    if not validate_package_name(name):
-        err_console = Console(stderr=True)
-        err_console.print(
-            Panel.fit(
-                f'⛔️ Package not created: {name} is not a valid Python package name',
-                title='pyprefab error',
-                border_style='red',
-            )
-        )
-        raise typer.Exit(1)
-
     # If there is already content in the package directory, exit (unless
     # the directory is on the exception list below)
     allow_existing = ['.git']

--- a/src/pyprefab/exceptions.py
+++ b/src/pyprefab/exceptions.py
@@ -1,0 +1,51 @@
+"""Custom exceptions for PyPrefab."""
+
+import typing as t
+from gettext import gettext as _
+
+import click
+import typer
+
+
+def style_message(message) -> str:
+    """
+    Style the message for display.
+
+    Use Click's style function to format the error message because error
+    messages emitted from the callback function of an interactive prompt
+    use Click's echo function, which does not support rich text.
+    https://click.palletsprojects.com/en/stable/api/#click.style
+    """
+    msg = click.style(f'{message}')  # colors would go here
+    msg = f'❌ {msg}'
+    return msg
+
+
+class PyprefabBadParameter(typer.BadParameter):
+    """Custom exception for bad parameters in PyPrefab CLI."""
+
+    def __init__(self, message: str):
+        super().__init__(message)
+        self.message = style_message(message)
+        self.show_color = True
+
+    def show(self, file: t.Optional[t.IO[t.Any]] = None) -> None:
+        """
+        Override show() method in Click exceptions.
+
+        This method is currently a no-op, because Click does not
+        use the show() method to print exception messages when the
+        exception comes from prompted input.
+
+        The related Click code is in termui.prompt(). To override the default
+        behavior, you can change the except UsageError block in prompt_func()
+        to:
+
+         except UsageError as e:
+            if hide_input:
+                echo(_("Error: The value you entered was invalid."), err=err)
+            else:
+               # use the exception's show() method to print the error message
+               e.show()
+        """
+        click.echo(_(self.message), err=True)

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -5,7 +5,38 @@ from unittest.mock import patch
 import pytest
 from typer.testing import CliRunner
 
-from pyprefab.cli import app  # type: ignore
+from pyprefab.cli import (
+    app,  # type: ignore
+    validate_package_name,
+)
+from pyprefab.exceptions import PyprefabBadParameter
+
+
+@pytest.mark.parametrize(
+    'package_name, expected_result',
+    [
+        ('valid_package_name', 'valid_package_name'),
+        ('valid_package_name123', 'valid_package_name123'),
+        ('AnnoyingButValid', 'AnnoyingButValid'),
+    ],
+)
+def test_valid_package_name(package_name, expected_result):
+    """Test package name validation."""
+    assert validate_package_name(package_name) == expected_result
+
+
+@pytest.mark.parametrize(
+    'package_name',
+    [
+        ('invalid-package-name'),
+        ('invalid-package-name!'),
+        ('1invalid_package_name'),
+    ],
+)
+def test_invalid_package_name(package_name):
+    """Test package name validation."""
+    with pytest.raises(PyprefabBadParameter):
+        validate_package_name(package_name)
 
 
 @pytest.mark.parametrize(
@@ -38,7 +69,7 @@ def test_pyprefab_cli(tmp_path, cli_inputs, expected_dirs):
     assert set(dir_names) == set(expected_dirs)
 
 
-def test_invalid_package_name(tmp_path):
+def test_app_invalid_package_name(tmp_path):
     """Package name must be a valid Python identifier."""
     runner = CliRunner()
     result = runner.invoke(


### PR DESCRIPTION
This PR switches moves the `--name` parameter validation to a callback function. This update ensures that people in interactive mode will get immediate feedback for invalid package names instead of filling out the remaining prompts first.