### PR TITLE
Use uv sync instead of uv pip install when setting up nox

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -67,13 +67,9 @@ def test_dev_install(session: nox.Session) -> None:
     """Install as a package and run tests."""
     session.run_install(
         'uv',
-        'pip',
-        'install',
-        '-e',
-        '.',
+        'sync',
+        '--active',
         '--group=dev',
-        '--quiet',
-        f'--python={session.virtualenv.location}',
     )
     session.run('pytest')
 


### PR DESCRIPTION
Reduce the amount of requirement virtualenv futzing and reduce any confusion between the uv .venv default and the location of the nox session virtual environment. 