### PR TITLE
Fix incorrect GitHub environment name i

### DIFF
--- a/src/pyprefab/templates/.github/workflows/publish-pypi.yaml.j2
+++ b/src/pyprefab/templates/.github/workflows/publish-pypi.yaml.j2
@@ -4,7 +4,7 @@
 # to PyPI and TestPyPI. The trusted publisher enables PyPI updates without
 # needing to store secrets in the repository.
 # There are three prerequisites:
-# 1. Create two GitHub environments named `pypi` and `test-pypi` in the
+# 1. Create two GitHub environments named `pypi` and `pypi-test` in the
 # project's repository
 # (if you use a different environment names, change the environment names
 # below to match)

--- a/test/__snapshots__/test_templates.ambr
+++ b/test/__snapshots__/test_templates.ambr
@@ -391,7 +391,7 @@
   # to PyPI and TestPyPI. The trusted publisher enables PyPI updates without
   # needing to store secrets in the repository.
   # There are three prerequisites:
-  # 1. Create two GitHub environments named `pypi` and `test-pypi` in the
+  # 1. Create two GitHub environments named `pypi` and `pypi-test` in the
   # project's repository
   # (if you use a different environment names, change the environment names
   # below to match)


### PR DESCRIPTION
Closes #70 

Fix incorrect GitHub environment name in the instructions at the top of the publish-pypi workflow template.