### PR TITLE
Switch boolean outputs to string

### DIFF
--- a/src/pyprefab/templates/.github/workflows/publish-pypi.yaml.j2
+++ b/src/pyprefab/templates/.github/workflows/publish-pypi.yaml.j2
@@ -35,10 +35,10 @@ jobs:
     name: Build distribution 📦
     runs-on: ubuntu-latest
     outputs:
-      # set publish_to_pypi = true to publish to PyPI after
+      # set publish_to_pypi to 'true' to publish to PyPI after
       # tagging a release (requires trusted publisher setup on PyPI)
-      publish_to_pypi: false
-      publish_to_testpypi: false
+      publish_to_pypi: 'false'
+      publish_to_testpypi: 'false'
 
     steps:
       - name: Checkout 🛎️

--- a/test/__snapshots__/test_templates.ambr
+++ b/test/__snapshots__/test_templates.ambr
@@ -422,10 +422,10 @@
       name: Build distribution 📦
       runs-on: ubuntu-latest
       outputs:
-        # set publish_to_pypi = true to publish to PyPI after
+        # set publish_to_pypi to 'true' to publish to PyPI after
         # tagging a release (requires trusted publisher setup on PyPI)
-        publish_to_pypi: false
-        publish_to_testpypi: false
+        publish_to_pypi: 'false'
+        publish_to_testpypi: 'false'
   
       steps:
         - name: Checkout 🛎️


### PR DESCRIPTION
Resolves #71 

GitHub docs state that steps.<step_id>.outputs.<output_name> evaluates as a string.